### PR TITLE
Spring 3 Upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: "temurin"
       - run: |
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: "temurin"
       - run: |
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.5</version>
+        <version>3.1.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>de.mirkosertic</groupId>
     <artifactId>flight-recorder-starter</artifactId>
     <version>2.3.1-SNAPSHOT</version>
     <name>flight-recorder-starter</name>
-    <description>Spring Boot 2 starter for Java Flight Recorder Actuator Endpoint</description>
+    <description>Spring Boot 3 starter for Java Flight Recorder Actuator Endpoint</description>
     <packaging>jar</packaging>
     <url>https://github.com/mirkosertic/flight-recorder-starter</url>
 
@@ -46,7 +46,7 @@
     </scm>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <dependencies>
@@ -68,17 +68,16 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 
@@ -150,7 +149,6 @@
                     <tagNameFormat>@{project.version}</tagNameFormat>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 

--- a/src/main/java/de/mirkosertic/flightrecorderstarter/core/FlightRecorder.java
+++ b/src/main/java/de/mirkosertic/flightrecorderstarter/core/FlightRecorder.java
@@ -170,7 +170,7 @@ public class FlightRecorder {
             } else if (this.configuration.getRecordingCleanupType() == FlightRecorderDynamicConfiguration.CleanupType.COUNT) {
                 deletableRecordings = getDeletableRecordingsByCount();
             } else { // can only happen in tests if cleanupType is not set
-                throw new IllegalArgumentException(String.format("Unknown CleanupType '%s'. Deletion failed.", this.configuration.getRecordingCleanupType()));
+                throw new IllegalArgumentException("Unknown CleanupType '%s'. Deletion failed.".formatted(this.configuration.getRecordingCleanupType()));
             }
 
             deletableRecordings.forEach(this::deleteRecording);

--- a/src/main/resources/META-INF/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+de.mirkosertic.flightrecorderstarter.configuration.FlightRecorderAutoConfiguration
+de.mirkosertic.flightrecorderstarter.configuration.FlightRecorderPropertiesAutoConfiguration

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  de.mirkosertic.flightrecorderstarter.configuration.FlightRecorderPropertiesAutoConfiguration,\
-de.mirkosertic.flightrecorderstarter.configuration.FlightRecorderAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration=de.mirkosertic.flightrecorderstarter.configuration.ManagementConfiguration

--- a/src/test/java/de/mirkosertic/flightrecorderstarter/actuator/FlightRecorderEndpointTest.java
+++ b/src/test/java/de/mirkosertic/flightrecorderstarter/actuator/FlightRecorderEndpointTest.java
@@ -172,7 +172,7 @@ class FlightRecorderEndpointTest {
     }
 
     @Test
-    public void givenRequest_whenTryToRetrieveAllRecordings_thenInternalServerErrorReturned() throws Exception {
+    void givenRequest_whenTryToRetrieveAllRecordings_thenInternalServerErrorReturned() throws Exception {
         //given
         given(this.mockFlightRecorder.sessions()).willThrow(IllegalArgumentException.class);
 
@@ -186,7 +186,7 @@ class FlightRecorderEndpointTest {
     }
 
     @Test
-    public void givenCorrectParams_whenTryToStopRecording_thenRecordingIdIsReturned() throws Exception {
+    void givenCorrectParams_whenTryToStopRecording_thenRecordingIdIsReturned() throws Exception {
         //given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willReturn(new File(getClass().getResource("/recording.jfr").toURI()));
 
@@ -201,7 +201,7 @@ class FlightRecorderEndpointTest {
     }
 
     @Test
-    public void givenNoExistingRecordingId_whenTryToStopRecording_thenNotFoundIsReturned() throws Exception {
+    void givenNoExistingRecordingId_whenTryToStopRecording_thenNotFoundIsReturned() throws Exception {
         //given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willReturn(null);
 
@@ -215,7 +215,7 @@ class FlightRecorderEndpointTest {
     }
 
     @Test
-    public void givenCorrectParams_whenTryToDeleteARecording_thenNoContentIsReturned() throws Exception {
+    void givenCorrectParams_whenTryToDeleteARecording_thenNoContentIsReturned() throws Exception {
         //given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willReturn(new File(getClass().getResource("/recording.jfr").toURI()));
 
@@ -230,7 +230,7 @@ class FlightRecorderEndpointTest {
     }
 
     @Test
-    public void givenNoExistingRecordId_whenTryToDeleteARecording_thenNotFoundIsReturned() throws Exception {
+    void givenNoExistingRecordId_whenTryToDeleteARecording_thenNotFoundIsReturned() throws Exception {
         //given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willReturn(null);
 
@@ -246,7 +246,7 @@ class FlightRecorderEndpointTest {
     }
 
     @Test
-    public void givenCorrectParams_whenTryToDeleteARecording_thenInternalServerErrorIsReturned() throws Exception {
+    void givenCorrectParams_whenTryToDeleteARecording_thenInternalServerErrorIsReturned() throws Exception {
         //given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willThrow(IllegalArgumentException.class);
 
@@ -261,7 +261,7 @@ class FlightRecorderEndpointTest {
     }
 
     @Test
-    public void givenCorrectParams_whenTryToDownloadRecording_thenRecordingIsReturned() throws Exception {
+    void givenCorrectParams_whenTryToDownloadRecording_thenRecordingIsReturned() throws Exception {
         //given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willReturn(new File(getClass().getResource("/recording.jfr").toURI()));
 
@@ -279,7 +279,7 @@ class FlightRecorderEndpointTest {
     }
 
     @Test
-    public void givenNoExistingRecordId_whenTryToDownloadRecording_thenNotFoundIsReturned() throws Exception {
+    void givenNoExistingRecordId_whenTryToDownloadRecording_thenNotFoundIsReturned() throws Exception {
         //given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willReturn(null);
 

--- a/src/test/java/de/mirkosertic/flightrecorderstarter/actuator/ReactiveFlightRecorderEndpointTest.java
+++ b/src/test/java/de/mirkosertic/flightrecorderstarter/actuator/ReactiveFlightRecorderEndpointTest.java
@@ -225,7 +225,7 @@ class ReactiveFlightRecorderEndpointTest {
      * Given request when try to retrieve all recordings then internal server error returned.
      */
     @Test
-    public void givenRequest_whenTryToRetrieveAllRecordings_thenInternalServerErrorReturned() {
+    void givenRequest_whenTryToRetrieveAllRecordings_thenInternalServerErrorReturned() {
         // given
         given(this.mockFlightRecorder.sessions()).willThrow(IllegalArgumentException.class);
 
@@ -246,7 +246,7 @@ class ReactiveFlightRecorderEndpointTest {
      * @throws Exception the exception
      */
     @Test
-    public void givenCorrectParams_whenTryToStopRecording_thenRecordingIdIsReturned() throws Exception {
+    void givenCorrectParams_whenTryToStopRecording_thenRecordingIdIsReturned() throws Exception {
         // given
         given(this.mockFlightRecorder.stopRecording(anyLong()))
                 .willReturn(new File(this.getClass().getResource("/recording.jfr").toURI()));
@@ -268,7 +268,7 @@ class ReactiveFlightRecorderEndpointTest {
      * Given no existing recording id when try to stop recording then not found is returned.
      */
     @Test
-    public void givenNoExistingRecordingId_whenTryToStopRecording_thenNotFoundIsReturned() {
+    void givenNoExistingRecordingId_whenTryToStopRecording_thenNotFoundIsReturned() {
         // given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willReturn(null);
 
@@ -289,7 +289,7 @@ class ReactiveFlightRecorderEndpointTest {
      * @throws Exception the exception
      */
     @Test
-    public void givenCorrectParams_whenTryToDeleteARecording_thenNoContentIsReturned() throws Exception {
+    void givenCorrectParams_whenTryToDeleteARecording_thenNoContentIsReturned() throws Exception {
         // given
         given(this.mockFlightRecorder.stopRecording(anyLong()))
                 .willReturn(new File(this.getClass().getResource("/recording.jfr").toURI()));
@@ -310,7 +310,7 @@ class ReactiveFlightRecorderEndpointTest {
      * Given no existing record id when try to delete a recording then not found is returned.
      */
     @Test
-    public void givenNoExistingRecordId_whenTryToDeleteARecording_thenNotFoundIsReturned() {
+    void givenNoExistingRecordId_whenTryToDeleteARecording_thenNotFoundIsReturned() {
         // given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willReturn(null);
 
@@ -331,7 +331,7 @@ class ReactiveFlightRecorderEndpointTest {
      * Given correct params when try to delete a recording then internal server error is returned.
      */
     @Test
-    public void givenCorrectParams_whenTryToDeleteARecording_thenInternalServerErrorIsReturned() {
+    void givenCorrectParams_whenTryToDeleteARecording_thenInternalServerErrorIsReturned() {
         // given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willThrow(IllegalArgumentException.class);
 
@@ -353,7 +353,7 @@ class ReactiveFlightRecorderEndpointTest {
      * @throws Exception the exception
      */
     @Test
-    public void givenCorrectParams_whenTryToDownloadRecording_thenRecordingIsReturned() throws Exception {
+    void givenCorrectParams_whenTryToDownloadRecording_thenRecordingIsReturned() throws Exception {
         // given
         given(this.mockFlightRecorder.stopRecording(anyLong()))
                 .willReturn(new File(this.getClass().getResource("/recording.jfr").toURI()));
@@ -381,7 +381,7 @@ class ReactiveFlightRecorderEndpointTest {
      * Given no existing record id when try to download recording then not found is returned.
      */
     @Test
-    public void givenNoExistingRecordId_whenTryToDownloadRecording_thenNotFoundIsReturned() {
+    void givenNoExistingRecordId_whenTryToDownloadRecording_thenNotFoundIsReturned() {
         // given
         given(this.mockFlightRecorder.stopRecording(anyLong())).willReturn(null);
 

--- a/src/test/java/de/mirkosertic/flightrecorderstarter/actuator/model/FlameGraphTest.java
+++ b/src/test/java/de/mirkosertic/flightrecorderstarter/actuator/model/FlameGraphTest.java
@@ -25,7 +25,7 @@ import java.net.URL;
 class FlameGraphTest {
 
     @Test
-    void testParsing() throws URISyntaxException, IOException {
+    void parsing() throws URISyntaxException, IOException {
         final URL url = getClass().getResource("/recording.jfr");
         final FlameGraph g = FlameGraph.from(new File(url.toURI()));
     }

--- a/src/test/java/de/mirkosertic/flightrecorderstarter/controller/FRStaticControllerCustomManagementPortIntegrationTest.java
+++ b/src/test/java/de/mirkosertic/flightrecorderstarter/controller/FRStaticControllerCustomManagementPortIntegrationTest.java
@@ -3,10 +3,10 @@ package de.mirkosertic.flightrecorderstarter.controller;
 import de.mirkosertic.flightrecorderstarter.fixtures.FlightRecorderStarterApplication;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.autoconfigure.web.server.LocalManagementPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +36,7 @@ class FRStaticControllerCustomManagementPortIntegrationTest {
         final ResponseEntity<Resource> response = this.testRestTemplate
                 .getForEntity(baseUrl + "/customActuator/flightrecorder/ui" + D3_V4_MIN_JS, Resource.class);
 
-        assertThat(response.getStatusCode()).isEqualByComparingTo(HttpStatus.OK);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
 

--- a/src/test/java/de/mirkosertic/flightrecorderstarter/controller/FlightRecorderStaticControllerTest.java
+++ b/src/test/java/de/mirkosertic/flightrecorderstarter/controller/FlightRecorderStaticControllerTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.mirkosertic.flightrecorderstarter.DummyTestMainClass;
 import de.mirkosertic.flightrecorderstarter.core.FlightRecorder;
 import de.mirkosertic.flightrecorderstarter.fixtures.FlightRecorderStarterApplication;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -25,6 +24,8 @@ import java.util.Map;
 import static de.mirkosertic.flightrecorderstarter.controller.FlightRecorderStaticController.*;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.TEXT_HTML;
@@ -270,13 +271,13 @@ class FlightRecorderStaticControllerTest {
 
         given(mockAppContext.getBeansWithAnnotation(SpringBootApplication.class)).willReturn(mockMap);
 
-        Assertions.assertEquals("de.mirkosertic.flightrecorderstarter.fixtures.FlightRecorderStarterApplication" ,
+        assertEquals("de.mirkosertic.flightrecorderstarter.fixtures.FlightRecorderStarterApplication" ,
                 this.flightRecorderStaticController.findBootClass(mockAppContext));
     }
 
     @Test
     void givenApplicationContextWithoutSpringBootApplicationBean_whenTryToFindBootClass_thenNullIsReturned() {
-        Assertions.assertNull(this.flightRecorderStaticController.findBootClass(this.applicationContext));
+        assertNull(this.flightRecorderStaticController.findBootClass(this.applicationContext));
     }
 
     @Test
@@ -292,7 +293,7 @@ class FlightRecorderStaticControllerTest {
         given(mockAppContextParent.getBeansWithAnnotation(SpringBootApplication.class)).willReturn(mockMap);
         given(mockAppContext.getParent()).willReturn(mockAppContextParent);
 
-        Assertions.assertEquals("de.mirkosertic.flightrecorderstarter.fixtures.FlightRecorderStarterApplication" ,
+        assertEquals("de.mirkosertic.flightrecorderstarter.fixtures.FlightRecorderStarterApplication" ,
                 this.flightRecorderStaticController.findBootClass(mockAppContext));
     }
 

--- a/src/test/java/de/mirkosertic/flightrecorderstarter/trigger/SPELTest.java
+++ b/src/test/java/de/mirkosertic/flightrecorderstarter/trigger/SPELTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(classes = FlightRecorderStarterApplication.class)
-public class SPELTest {
+class SPELTest {
 
     @Autowired
     BeanFactory beanFactory;
@@ -42,7 +42,7 @@ public class SPELTest {
     MeterRegistry meterRegistry;
 
     @Test
-    void testEvaluate() {
+    void evaluate() {
 
         final MicrometerAdapter adapter = new MicrometerAdapter(this.meterRegistry);
         final SpelParserConfiguration config = new SpelParserConfiguration(SpelCompilerMode.IMMEDIATE, this.getClass().getClassLoader());


### PR DESCRIPTION
Wanted to kick off the conversation for Spring 3 support. These are not 100% of the changes needed but it's pretty close. Only missing piece are the 404s when hitting endpoints with dangling slash like `actuator/flightrecorder/` due to  https://github.com/spring-projects/spring-framework/issues/28552 

The actual cause of these failures are due to the `PUT` endpoint no longer returning a value in the body, I'll look into that separately.

What are your thoughts on adding support for Spring 3 in this library? Would a standalone Spring 3 branch make sense for releasing purposes?

I'd also like to contribute the ability to have constantly running recordings that can be accessed so looking forward to discussing those possibilities as well.

